### PR TITLE
Add redirects to routeMaps

### DIFF
--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -125,8 +125,12 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
             }));
 
             // Make routeMap
-            _.each(pageOptions.routes, function mapRoute(route) {
-              routeMap[route] = pageOptions.filename;
+            _.each(pageOptions.routes, function mapRoute(route, index) {
+              if (index === 0) {
+                _.set(routeMap, 'rewrites["' + route + '"]', pageOptions.filename);
+              } else {
+                _.set(routeMap, 'redirects["' + route + '"]', _.first(pageOptions.routes));
+              }
             });
           });
 


### PR DESCRIPTION
This PR updates the `routeMap` schema to differentiate between rewrites (point a route to a specific file) and redirects (point a route to another route). If a given page has multiple routes, only the first route will be treated as a rewrite, and all remaining routes will be redirects.

This PR also updates the static-site middleware to differentiate between redirects and rewrites.