### PR TITLE
update gh syntax and add package-lock.json file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 bower_components
 *.sublime-workspace
+package-lock.json


### PR DESCRIPTION
The GitHub syntax for `reporter-plus` repository has been updated earlier but is not getting picked up in the `website_v2`. Found the old syntax in package-lock.json file of `website_v2` due to `web-tools-ds` and `web-tools-static-site`. Builds are failing due to this.

<img width="1326" alt="Screen Shot 2022-03-21 at 9 37 41 AM" src="https://user-images.githubusercontent.com/89473231/159313542-bd59c997-90b1-4493-a7be-dff329e868a3.png">


<img width="1356" alt="Screen Shot 2022-03-21 at 9 37 54 AM" src="https://user-images.githubusercontent.com/89473231/159313644-a94c8406-4e1b-4ad8-9b0d-ed6911cfe0d4.png">
