### PR TITLE
[PE-2356 & PE-2353] Update Routemap for sitemap.xml for Static Sites

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "node-fetch": "^2.6.0",
     "reporter-plus": "git+https://github.com/jayeb/reporter-plus.git",
     "through2": "^2.0.1",
-    "vinyl": "^2.0.2"
+    "vinyl": "^2.0.2",
+    "yargs": "^17.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tools-static-site",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Web-tools plugin for building and serving a static site based on a datastore, a set of compiled templates and a configuration file.",
   "repository": {
     "type": "git",
@@ -10,8 +10,10 @@
   "license": "BSD",
   "main": "tools/web-tools-static-site.js",
   "dependencies": {
+    "async-dash": "^1.0.4",
     "express": "^4.15.4",
     "lodash": "4.17.21",
+    "node-fetch": "^2.6.0",
     "reporter-plus": "git+https://github.com/jayeb/reporter-plus.git",
     "through2": "^2.0.1",
     "vinyl": "^2.0.2"

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -159,11 +159,11 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
                 lastModDates = [];
 
               // Matches template name to template's sub directory. Make sure the subdirectory matches template name in repo
-              if(templatesSubDirArray) {
-                for(let subDir of templatesSubDirArray) {
-                  if(templatesSubDir[pageOptions.template]) {
+              if (templatesSubDirArray) {
+                for (let subDir of templatesSubDirArray) {
+                  if (templatesSubDir[pageOptions.template]) {
                     continue;
-                  } else if (pageOptions.template.indexOf(subDir) > 0){
+                  } else if (pageOptions.template.indexOf(subDir) > 0) {
                     templatesSubDir[pageOptions.template] = subDir;
                   }
                 }

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -151,12 +151,12 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
 
             if(!!args.generate) {
               var baseAPIPath = `https://api.github.com/repos/zebrafishlabs/${repo}/commits`,
-              contentFile = pageOptions.data.contentDirectory || pageOptions.data.content?.contentDirectory,
-              contentPath,
-              templatePathArray = [siteBase, templatesDir],
-              templatePath,
-              apiPath = (path) => baseAPIPath + `?path=${path}`,
-              lastModDates = [];
+                contentFile = pageOptions.data.contentDirectory || pageOptions.data.content?.contentDirectory,
+                contentPath,
+                templatePathArray = [siteBase, templatesDir],
+                templatePath,
+                apiPath = (path) => baseAPIPath + `?path=${path}`,
+                lastModDates = [];
 
               // Matches template name to template's sub directory. Make sure the subdirectory matches template name in repo
               if(templatesSubDirArray) {

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -174,7 +174,7 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               templatePath = templatePathArray.join('/');
 
               // Makes individual API calls for most recent modified dates for jobscore + content and template files for each route
-              if(pageOptions.routes[0] === ('/careers')) {
+              if (pageOptions.routes[0] === ('/careers')) {
                 await fetch(jobScoreURL)
                   .then(data => data.json())
                   .then((jobsData) => {

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -150,13 +150,14 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
 
 
             var baseAPIPath = `https://api.github.com/repos/zebrafishlabs/${repo}/commits`,
-            contentPath = contentBase.concat('/', pageOptions.data.contentDirectory ?? pageOptions.data.content?.contentDirectory),
+            contentFile = pageOptions.data.contentDirectory || pageOptions.data.content?.contentDirectory,
+            contentPath,
             templatePathArray = [siteBase, templatesDir],
             templatePath,
             apiPath = (path) => baseAPIPath + `?path=${path}`,
-            lastModDates = [],
-            hasContentFile = pageOptions.data.contentDirectory || (pageOptions.data.content?.contentDirectory);
+            lastModDates = [];
 
+            // Matches template name to template's sub directory. Make sure the subdirectory matches template name in repo
             if(templatesSubDirArray) {
               for(let subDir of templatesSubDirArray) {
                 if(templatesSubDir[pageOptions.template]) {
@@ -166,12 +167,12 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
                 }
               }
 
-              templatePathArray.push(templatesSubDir[pageOptions.template]);
-              templatePathArray.push(pageOptions.template)
+              templatePathArray.push(templatesSubDir[pageOptions.template], pageOptions.template);
             }
 
             templatePath = templatePathArray.join('/');
 
+            // Makes individual API calls for most recent modified dates for jobscore + content and template files for each route
             if(pageOptions.routes[0] === ('/careers')) {
               await fetch(jobScoreURL)
               .then(data => data.json())
@@ -183,7 +184,9 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               });
             }
 
-            if(hasContentFile) {
+            if(contentFile) {
+              contentPath = contentBase.concat('/', contentFile)
+
               await fetch(apiPath(contentPath), {
                 headers: { 'Authorization': `Bearer ${accessToken}` }
               })

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -176,13 +176,13 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               // Makes individual API calls for most recent modified dates for jobscore + content and template files for each route
               if(pageOptions.routes[0] === ('/careers')) {
                 await fetch(jobScoreURL)
-                .then(data => data.json())
-                .then((jobsData) => {
-                  lastModDates.push(jobsData.last_updated);
-                })
-                .catch(function onError(error) {
-                  console.log('Error fetching from ' + jobScoreURL + ':', error);
-                });
+                  .then(data => data.json())
+                  .then((jobsData) => {
+                    lastModDates.push(jobsData.last_updated);
+                  })
+                  .catch(function onError(error) {
+                    console.log('Error fetching from ' + jobScoreURL + ':', error);
+                  });
               }
 
               if(contentFile) {


### PR DESCRIPTION
# Description

This PR updates the routemap object which takes data from our static site and transforms it before passing it on to site-shared routemap build pipeline to generate the sitemap.xml. Formerly, this object only contained `rewrites` and `reroutes`. This adds `sitemapXML` property with `lastModDate` and `priority` values, the former is retrieved by API calls to Github and jobscore and the latter is received as data from our static site data which has been updated in a separated PR. 

<!---

Explain why the changes are being proposed, what changes are being proposed, and how you chose to implement the change.

If there are visual updates, please provide before/after screenshots or gifs.

--->


# Links

<!--- Please remove any that don't apply and add additional links if needed. --->

Jira: 
https://imgix.atlassian.net/browse/PE-2353
https://imgix.atlassian.net/browse/PE-2356

Related pull requests: 
site-shared build update: https://github.com/zebrafishlabs/site-shared/pull/60
website data update: https://github.com/zebrafishlabs/website_v2/pull/288

Design: 

Staging: 


# Additional Info

To test, pull down this branch and the branches linked above to site-shared and website_v2 ^

In the web-tools-static-site and site-shared branches, do `yarn link`

Then go to website_v2 to `yarn link web-tools-static-site` and `yarn link site-shared` and then run `gulp --generate`

You should see the generated sitemap at `/sitemap.xml`

<!--- Anything else? --->
