### PR TITLE
[PE-2353 & PE-2356] Updates sitemap.xml functionality 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tools-static-site",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Web-tools plugin for building and serving a static site based on a datastore, a set of compiled templates and a configuration file.",
   "repository": {
     "type": "git",

--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -149,9 +149,9 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               }
             });
 
-            if(!!args.generate) {
+            if(!!args.generate && pageOptions.routes[0][0] !== '#') {
               var baseAPIPath = `https://api.github.com/repos/zebrafishlabs/${repo}/commits`,
-                contentFile = pageOptions.data.contentDirectory || pageOptions.data.content?.contentDirectory,
+                contentFile = pageOptions.data.contentDirectory || pageOptions.data.content?.contentDirectory || pageOptions.data.post?.contentDirectory,
                 contentPath,
                 templatePathArray = [siteBase, templatesDir],
                 templatePath,


### PR DESCRIPTION
This PR updates the `sitemap.xml` function for blog and docs to grab data from `post` in addition to content and exclude routes with `#`

jira:
https://imgix.atlassian.net/browse/PE-2356
https://imgix.atlassian.net/browse/PE-2353

related PRs:
https://github.com/zebrafishlabs/imgix-blog/pull/405
https://github.com/zebrafishlabs/docs/pull/621

To test, pull down this branch and the branches linked above to blog and docs ^

In the web-tools-static-site branch, do yarn link

Then go to blog and docs to yarn link web-tools-static-site and run gulp --generate

You should see the generated sitemap at `/sitemap.xml`