### PR TITLE
[PE-3467] Update sitemap.xml logic to use Contentful instead of Github for blog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tools-static-site",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Web-tools plugin for building and serving a static site based on a datastore, a set of compiled templates and a configuration file.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
# Description

This PR uses `lastModDate`  property for the sitemap.xml so that it can be used instead of fetching from the github API with the content path. To test, `yarn link` this branch in blog: https://github.com/zebrafishlabs/imgix-blog/pull/415
<!---

Explain why the changes are being proposed, what changes are being proposed, and how you chose to implement the change.

If there are visual updates, please provide before/after screenshots or gifs.

--->


# Links

<!--- Please remove any that don't apply and add additional links if needed. --->

Jira: https://imgix.atlassian.net/browse/PE-3467

Related pull requests: 
https://github.com/zebrafishlabs/imgix-blog/pull/415

Design: 

Staging: 


# Additional Info

<!--- Anything else? --->
