### PR TITLE
[PE-3752] Updates date format for sitemap requirement

### DIFF
--- a/tools/pipelines/pipeline.static-site.js
+++ b/tools/pipelines/pipeline.static-site.js
@@ -97,7 +97,7 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               errors = {},
               routeMap = {},
               templatesSubDir = {};
-          
+
           await asyncDash.asyncEach(pageList, async function renderAndMapRoutes(pageOptions) {
             var template,
                 renderedPage;
@@ -135,7 +135,7 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
             if (_.isNull(renderedPage) || _.isUndefined(renderedPage)) {
               return;
             }
-            
+
             stream.push(new Vinyl({
               path: pageOptions.filename,
               contents: new Buffer(renderedPage)
@@ -159,7 +159,7 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
                 apiPath = (path) => baseAPIPath + `?path=${path}`,
                 lastModDates = [],
                 route = pageOptions.routes[0];
-              
+
               if (route === '/') route = '';
 
               if (pageOptions.lastModDate) lastModDates.push(pageOptions.lastModDate);
@@ -199,7 +199,7 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
                 })
                 .then(data => data.json())
                 .then((commit) => {
-                  lastModDates.push(new Date(commit[0].commit.committer.date));
+                  lastModDates.push(new Date(commit[0].commit.committer.date).toISOString());
                 })
                 .catch(function onError(error) {
                   console.log('Error fetching from ' + apiPath(contentPath) + ':', error);
@@ -211,8 +211,9 @@ module.exports = function setupNunjucksPagesPipeline(gulp) {
               })
               .then(data => data.json())
               .then((commit) => {
-                lastModDates.push(new Date (commit[0].commit.committer.date));
-                _.set(routeMap, 'sitemapXML["' + route + '"][lastModDate]', JSON.stringify(lastModDates.reduce((date, currentDate)=> date > currentDate ? date : currentDate)));
+                lastModDates.push(new Date (commit[0].commit.committer.date).toISOString());
+                _.set(routeMap, 'sitemapXML["' + route + '"][lastModDate]', lastModDates.reduce((date, currentDate)=> {
+                  return date > currentDate ? date : currentDate}));
               })
               .catch(function onError(error) {
                 console.log('Error fetching from ' + apiPath(templatePath) + ':', error);


### PR DESCRIPTION
# Description
This PR addresses a sitemap bug that google was throwing a warning towards. 
- The date format was including a weekday and timezone text. Now it is an accepted format with `toISOString()` - `2023-01-26T18:20:04.000Z`
- `JSON.stringify()` was removed as it was causing unaccepted behavior of making a string within a string, ex: " ' 2023-01-26T18:20:04.000Z' "

## How to test

Steps:
1. Pull branch and `yarn link website-v2`
2. In `website-v2` - `gulp --generate` to generate sitemap files
3. See sitemap preview http://localhost:9060/sitemap.xml
  - lastmod is now the correct format 
**Before:**
<img width="578" alt="Screen Shot 2023-05-02 at 11 16 24 AM" src="https://user-images.githubusercontent.com/49009626/235751116-4f3a051c-0f9a-4c6e-ae01-5dd18aac84e1.png">

**After:**
<img width="453" alt="Screen Shot 2023-05-02 at 11 16 06 AM" src="https://user-images.githubusercontent.com/49009626/235751146-77fc83ea-a8b9-47e2-b4ac-947ad426babf.png">

# Links
[Jira](https://imgix.atlassian.net/browse/PE-3752)
